### PR TITLE
Actions for unit tests and code quality

### DIFF
--- a/.github/workflows/build-unittest.yml
+++ b/.github/workflows/build-unittest.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests with multiple 
+# Python versions. We checkout the branch, install the package from scratch, then
+# try and run the unit tests.
+
+name: Build and run unit tests
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+    - 'p3/**'
+    - 'tests/**'
+    - 'pyproject.toml'
+    - 'MANIFEST.in'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+    - 'p3/**'
+    - 'tests/**'
+    - 'pyproject.toml'
+    - 'MANIFEST.in'
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install p3 and its dependencies
+      run: pip install --no-cache-dir './[dev]'
+    - name: Run unittest
+      run: python -m unittest discover -s tests --verbose
+

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,0 +1,47 @@
+name: Format with black and lint with Flake8
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'p3/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'p3/**'
+
+jobs:
+  format:
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        name: Install Python 3.9
+        with:
+          python-version: "3.9"
+      - name: Install black
+        run: |
+          pip install black==22.12.0
+      - name: Run black formatter
+        run: |
+          black ./p3
+      - name: Commit formatting changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "style: automated code formatting with black"
+          commit_user_name: "Github Actions Black"
+          status_options: '--untracked-files=no'
+  lint:
+    needs: format
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        name: Install Python 3.9
+        with:
+          python-version: "3.9"
+      - name: Install flake8 and plugins
+        run: |
+          pip install flake8 flake8-pyproject flake8-black flake8-bandit
+      - name: Run flake8 on the package only
+        run: |
+          flake8 ./p3
+


### PR DESCRIPTION
# Proposed changes

This PR adds Github actions workflows for the following:

- Build and run unit tests for Python 3.8, 3.9, and 3.10
- Run `black` formatter, push changes if any to the working branch, and subsequently run `flake8`
