### PR TITLE
Align README dependencies with pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ data.
 
 ## Dependencies
 
-- matplotlib
+- jsonschema
+- numpy
+- matplotlib >= 3.6.3
 - pandas
 - Python >= 3.8
 


### PR DESCRIPTION
Prior to this commit, the README was missing two dependencies (specifically numpy and jsonschema). Developers installing the dependencies manually (i.e. without pip) were hitting errors.

# Related issues

N/A

# Proposed changes

- Add numpy and jsonschema to the dependency list in the README.
- Clarify that a specific version of matplotlib is required.
