### PR TITLE
Github action for commit sign-off checks

### DIFF
--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -19,3 +19,4 @@ jobs:
           excludeDescription: 'true'
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -16,3 +16,6 @@ jobs:
         with:
           pattern: 'Signed-off-by:'
           error: "Commit message does not include DCO signature; please see CONTRIBUTING.md."
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'

--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -1,0 +1,18 @@
+name: DCO commit signoff check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-commit-message:
+    name: Check commit message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Searching for "Signed-off"
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: 'Signed-off-by:'
+          error: "Commit message does not include DCO signature; see CONTRIBUTING.md!"

--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Searching for "Signed-off"
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: 'Signed-off-by:'
+          pattern: 'Signed-off-by: \S+( \S+)* <\S+@\S+>'
           error: "Commit message does not include DCO signature; please see CONTRIBUTING.md."
           excludeDescription: 'true'
           excludeTitle: 'true'

--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -15,4 +15,4 @@ jobs:
         uses: gsactions/commit-message-checker@v2
         with:
           pattern: 'Signed-off-by:'
-          error: "Commit message does not include DCO signature; see CONTRIBUTING.md!"
+          error: "Commit message does not include DCO signature; please see CONTRIBUTING.md."


### PR DESCRIPTION
This action should check in the latest commit of a pull request or push to make esure it contains "Signed-off-by" in the message, aligning with the DCO requirement in CONTRIBUTING.md

# Related issues

N/A

# Proposed changes

This PR adds a Github action that will parse commit messages in pull requests and pushes for "Signed-off-by", which is a requirement for DCO sign-off as stated in `CONTRIBUTING.md`.

- Adds a new Github action
- Github action uses `gsactions/commit-message-checker@v2`
- Searches for pattern "Signed-off-by"

The check is rather simplistic but should be reliable. Ideally we would want to capture name and email address to match the contributing guideline exactly, but I don't know a reliable way to capture names using just regex - it's not easy to do it for English (number of words, hyphenation, case), let alone other languages.
