### PR TITLE
Exclude PR merge commits from sign-off message checking workflow

### DIFF
--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -1,8 +1,6 @@
 name: DCO commit signoff check
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
# Related issues

Resolves #15.

# Proposed changes

Adds a conditional statement in the Github workflow definition for the commit message checker: we will only execute the workflow if "Merge pull request" is __not__ detected in the head commit message.
