### PR TITLE
Reconfiguring `black` workflow

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --diff"
+          options: "--check --verbose --diff --color"
           src: "./p3"
           version: "22.12.0"
   lint:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -15,22 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        name: Install Python 3.9
+      - uses: psf/black@stable
         with:
-          python-version: "3.9"
-      - name: Install black
-        run: |
-          pip install black==22.12.0
-      - name: Run black formatter
-        run: |
-          black ./p3
-      - name: Commit formatting changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "style: automated code formatting with black"
-          commit_user_name: "Github Actions Black"
-          status_options: '--untracked-files=no'
+          options: "--check --verbose --diff"
+          src: "./p3"
+          version: "22.12.0"
   lint:
     runs-on: ubuntu-latest
     needs: format

--- a/p3/_utils.py
+++ b/p3/_utils.py
@@ -12,7 +12,9 @@ def _require_columns(df, columns):
 
     for column in columns:
         if column not in df:
-            msg = ("DataFrame does not contain a column named '%s'. The following columns are required: %s"
+            msg = (
+                "DataFrame does not contain a column named '%s'. "
+                "The following columns are required: %s"
             )
             raise ValueError(msg % (column, str(columns)))
 

--- a/p3/_utils.py
+++ b/p3/_utils.py
@@ -12,9 +12,7 @@ def _require_columns(df, columns):
 
     for column in columns:
         if column not in df:
-            msg = (
-                "DataFrame does not contain a column named '%s'. "
-                "The following columns are required: %s"
+            msg = ("DataFrame does not contain a column named '%s'. The following columns are required: %s"
             )
             raise ValueError(msg % (column, str(columns)))
 


### PR DESCRIPTION
This PR reconfigures the `black` formatter part of the `lint-format` workflow by removing the autocommit action, and relying on the official `psf` version of the Github action.

The intention now is that the `black` workflow will simply check files within the `p3` source for modifications that `black` _would_ perform, as opposed to making and committing the changes.

# Related issues

Fixes #19 

# Proposed changes

List out&mdash;with high level descriptions&mdash;what the commits
within this PR do:

- Remove `auto-commit` action which wasn't working as intended, per #19
- Remove Python setup within `black` workflow
- Remove `black` installation within workflow
- Change to using `psf/black@stable` for configuring and running `black` on the code
- Added `black` options per #19; `--check --verbose --diff`
