### PR TITLE
Drop duplicate results

### DIFF
--- a/p3/metrics/_pp.py
+++ b/p3/metrics/_pp.py
@@ -83,6 +83,12 @@ def pp(df):
         if not df[eff].fillna(0).between(0, 1).all():
             raise ValueError("%s must in range [0, 1]" % eff)
 
+    # Keep only the most efficient (application, platform) results.
+    key = ["problem", "platform", "application"]
+    groups = df[key + efficiencies].groupby(key)
+    df = groups.agg(max)
+    df.reset_index(inplace=True)
+
     # Add a "did not run" value for applications that did not run
     rows = []
     combination_keys = ["problem", "platform", "application"]

--- a/p3/plot/_cascade.py
+++ b/p3/plot/_cascade.py
@@ -347,6 +347,12 @@ def cascade(df, eff=None, size=(6, 5), **kwargs):
             raise ValueError(msg % (eff_column))
     _require_numeric(df, [eff_column])
 
+    # Keep only the most efficient (application, platform) results.
+    key = ["problem", "platform", "application"]
+    groups = df[key + [eff_column]].groupby(key)
+    df = groups.agg(max)
+    df.reset_index(inplace=True)
+
     platforms = df["platform"].unique()
     applications = df["application"].unique()
 

--- a/tests/metrics/test_pp.py
+++ b/tests/metrics/test_pp.py
@@ -134,6 +134,31 @@ class TestPP(unittest.TestCase):
 
         pd.testing.assert_frame_equal(result, expected_df)
 
+    def test_pp_duplicates(self):
+        """p3.data.pp.duplicates"""
+
+        # Regression for case with duplicate result
+        data = {
+            "problem": ["test"] * 4,
+            "platform": ["A", "A", "B", "B"],
+            "application": ["latest"] * 4,
+            "fom": [float("NaN"), 25.0, 1.0, 2.0],
+            "app eff": [0, 1.0, 0.5, 1.0],
+            "arch eff": [0, 0.5, 0.25, 0.5],
+        }
+        df = pd.DataFrame(data)
+
+        result = pp(df)
+
+        expected_data = {
+            "problem": ["test"],
+            "application": ["latest"],
+            "app pp": [1.0],
+            "arch pp": [0.5],
+        }
+        expected_df = pd.DataFrame(expected_data)
+
+        pd.testing.assert_frame_equal(result, expected_df)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Enables correct results if dataframe contains multiple results for one (application, platform) pair.
- Selects the best efficiencies for a given (application, platform) pair to ensure correct results.

I considered making `pp` and `cascade` throw an error if the dataframe contained duplicate results, but handling this within the library itself seemed more user-friendly.
