### PR TITLE
Explicit settings for workflow permissions

### DIFF
--- a/.github/workflows/build-unittest.yml
+++ b/.github/workflows/build-unittest.yml
@@ -35,4 +35,4 @@ jobs:
       run: pip install --no-cache-dir './[dev]'
     - name: Run unittest
       run: python -m unittest discover -s tests --verbose
-
+permissions: read-all

--- a/.github/workflows/commit-signoff-check.yml
+++ b/.github/workflows/commit-signoff-check.yml
@@ -18,3 +18,4 @@ jobs:
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
           accessToken: ${{ secrets.GITHUB_TOKEN }}
+permissions: read-all

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Run flake8 on the package only
         run: |
           flake8 ./p3
-
+permissions: read-all


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

This PR adds `permissions` entries to the three Github actions workflows to explicitly to `read-all`.
