### PR TITLE
Simplify schema handling

### DIFF
--- a/p3/data/_validation.py
+++ b/p3/data/_validation.py
@@ -3,37 +3,7 @@
 
 import json
 import jsonschema
-
-_coverage_schema_id = (
-    "https://raw.githubusercontent.com/intel/"
-    "p3-analysis-library/p3/schema/coverage-0.1.0.schema"
-)
-_coverage_schema = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": _coverage_schema_id,
-    "title": "Coverage",
-    "description": "Lines of code used in each file of a code base.",
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "file": {"type": "string"},
-            "regions": {
-                "type": "array",
-                "items": {
-                    "type": "array",
-                    "prefixItems": [
-                        {"type": "integer"},
-                        {"type": "integer"},
-                        {"type": "integer"},
-                    ],
-                    "items": False,
-                },
-            },
-        },
-        "required": ["file", "regions"],
-    },
-}
+import pkgutil
 
 
 def _validate_coverage_json(json_string: str) -> object:
@@ -63,8 +33,15 @@ def _validate_coverage_json(json_string: str) -> object:
 
     instance = json.loads(json_string)
 
+    schema_string = pkgutil.get_data(__name__, "coverage-0.1.0.schema")
+    if not schema_string:
+        msg = "Could not locate coverage schema file"
+        raise RuntimeError(msg)
+
+    schema = json.loads(schema_string)
+
     try:
-        jsonschema.validate(instance=instance, schema=_coverage_schema)
+        jsonschema.validate(instance=instance, schema=schema)
     except Exception:
         msg = "Coverage string failed schema validation"
         raise ValueError(msg)

--- a/p3/data/_validation.py
+++ b/p3/data/_validation.py
@@ -42,8 +42,11 @@ def _validate_coverage_json(json_string: str) -> object:
 
     try:
         jsonschema.validate(instance=instance, schema=schema)
-    except Exception:
+    except jsonschema.exceptions.ValidationError:
         msg = "Coverage string failed schema validation"
         raise ValueError(msg)
+    except jsonschema.exceptions.SchemaError:
+        msg = "coverage-0.1.0.schema is not a valid schema"
+        raise RuntimeError(msg)
 
     return instance

--- a/p3/data/coverage-0.1.0.schema
+++ b/p3/data/coverage-0.1.0.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/intel/p3-analysis-library/p3/schema/coverage-0.1.0.schema",
+  "$id": "https://raw.githubusercontent.com/intel/p3-analysis-library/main/p3/data/coverage-0.1.0.schema",
   "title": "Coverage",
   "description": "Lines of code used in each file of a code base.",
   "type": "array",


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Load coverage schema from file to simplify validation code.
- Fix an incorrect URL in the coverage schema itself.

---

The original behavior (with duplication) was implemented primarily because I didn't know how to load a file from the current package.  If reviewers agree that this is a better way to handle our schema files, I'll roll out an equivalent fix to Code Base Investigator shortly.
