### PR TITLE
Update coverage schema to 0.2.0

### DIFF
--- a/p3/data/_validation.py
+++ b/p3/data/_validation.py
@@ -33,7 +33,7 @@ def _validate_coverage_json(json_string: str) -> object:
 
     instance = json.loads(json_string)
 
-    schema_string = pkgutil.get_data(__name__, "coverage-0.1.0.schema")
+    schema_string = pkgutil.get_data(__name__, "coverage-0.2.0.schema")
     if not schema_string:
         msg = "Could not locate coverage schema file"
         raise RuntimeError(msg)

--- a/p3/data/coverage-0.2.0.schema
+++ b/p3/data/coverage-0.2.0.schema
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/intel/p3-analysis-library/main/p3/data/coverage-0.2.0.schema",
+  "title": "Coverage",
+  "description": "Lines of code used in each file of a code base.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "regions": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "required": [
+      "file",
+      "regions"
+    ]
+  }
+}


### PR DESCRIPTION
The previous schema did not allow for coverage files to contain path information. While a file hash is sufficient to identify uniqueness when computing divergence, a path is more useful to humans and downstream tools.

The new schema allows for coverage files to contain both a file hash and (optional) path information.

# Related issues

N/A

# Proposed changes

- Update the coverage schema to allow coverage files to contain path information as well as a hash.
- Use the new coverage schema by default.
- Keep the old coverage schema around (for now) because a previous Code Base Investigator release references it.
