### PR TITLE
Add missing 0.2 schema to fix pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include p3/data/coverage-0.1.0.schema
+include p3/data/coverage-0.2.0.schema


### PR DESCRIPTION
Wasn't sure if it was better to hit you with an issue, or a possible fix (since I'm only 80% on this fix..) but this PR tries to address an issue where your pip install misses a file, causing:

```
  File "/Users/robertbird/homebrew/lib/python3.10/site-packages/p3/metrics/_divergence.py", line 75, in _coverage_string_to_json
    return _validate_coverage_json(string)
  File "/Users/robertbird/homebrew/lib/python3.10/site-packages/p3/data/_validation.py", line 36, in _validate_coverage_json
    schema_string = pkgutil.get_data(__name__, "coverage-0.2.0.schema")
  File "/Users/robertbird/homebrew/Cellar/python@3.10/3.10.7/Frameworks/Python.framework/Versions/3.10/lib/python3.10/pkgutil.py", line 639, in get_data
    return loader.get_data(resource_name)
  File "<frozen importlib._bootstrap_external>", line 1073, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/Users/robertbird/homebrew/lib/python3.10/site-packages/p3/data/coverage-0.2.0.schema'
```

# Related issues

"N/A".

# Proposed changes

Author: Bob <robertbird@google.com>
Date:   Wed Mar 20 10:36:35 2024 -0600

    Add missing 0.2 schema to fix pip install****