### PR TITLE
Update coverage schema to 0.3.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include p3/data/coverage-0.1.0.schema
 include p3/data/coverage-0.2.0.schema
+include p3/data/coverage-0.3.0.schema

--- a/p3/data/_validation.py
+++ b/p3/data/_validation.py
@@ -33,7 +33,7 @@ def _validate_coverage_json(json_string: str) -> object:
 
     instance = json.loads(json_string)
 
-    schema_string = pkgutil.get_data(__name__, "coverage-0.2.0.schema")
+    schema_string = pkgutil.get_data(__name__, "coverage-0.3.0.schema")
     if not schema_string:
         msg = "Could not locate coverage schema file"
         raise RuntimeError(msg)
@@ -46,7 +46,7 @@ def _validate_coverage_json(json_string: str) -> object:
         msg = "Coverage string failed schema validation"
         raise ValueError(msg)
     except jsonschema.exceptions.SchemaError:
-        msg = "coverage-0.1.0.schema is not a valid schema"
+        msg = "coverage-0.3.0.schema is not a valid schema"
         raise RuntimeError(msg)
 
     return instance

--- a/p3/data/coverage-0.3.0.schema
+++ b/p3/data/coverage-0.3.0.schema
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/intel/p3-analysis-library/main/p3/data/coverage-0.3.0.schema",
+  "title": "Coverage",
+  "description": "Lines of code used in each file of a code base.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "file": {
+        "type": "string"
+      },
+      "id": {
+        "type": "string"
+      },
+      "lines": {
+        "type": "array",
+        "items": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "array",
+                    "contains": {
+                        "type": "integer"
+                    },
+                    "minContains": 2,
+                    "maxContains": 2
+                }
+            ]
+        }
+      }
+    },
+    "required": [
+      "file",
+      "id",
+      "lines"
+    ]
+  }
+}

--- a/p3/metrics/_divergence.py
+++ b/p3/metrics/_divergence.py
@@ -55,15 +55,22 @@ def _coverage_to_divergence(maps):
     linemap = collections.defaultdict(set)
     for p, coverage in enumerate(maps):
         for entry in coverage:
-            fn = entry["file"]
-            for region in entry["regions"]:
-                linemap[(fn, tuple(region))].add(p)
+            unique_fn = (entry["file"], entry["id"])
+            for region in entry["lines"]:
+
+                # If a region is a single integer, it represents one line.
+                if isinstance(region, int):
+                    line = region
+                    linemap[(unique_fn, line)].add(p)
+
+                # If a region is a list, it represents a [start, end] pair.
+                if isinstance(region, list):
+                    for line in range(region[0], region[1]):
+                        linemap[(unique_fn, line)].add(p)
 
     setmap = collections.defaultdict(int)
     for key, platforms in linemap.items():
-        fn, triple = key
-        start, end, num_lines = triple
-        setmap[frozenset(platforms)] += num_lines
+        setmap[frozenset(platforms)] += 1
 
     return _average_distance(setmap)
 

--- a/tests/data/test_validation.py
+++ b/tests/data/test_validation.py
@@ -13,19 +13,19 @@ class TestValidation(unittest.TestCase):
 
     def test_coverage_json_valid(self):
         """p3.data.validation.coverage_json_valid"""
-        json_string = '[{"file": "id", "regions": [[1,2,3]]}]'
+        json_string = '[{"file": "path", "id": "sha", "lines": [1, 2, [3, 5]]}]'
         result_object = _validate_coverage_json(json_string)
-        expected_object = [{"file": "id", "regions": [[1, 2, 3]]}]
+        expected_object = [{"file": "path", "id": "sha", "lines": [1, 2, [3, 5]]}]
         self.assertTrue(result_object == expected_object)
 
     def test_coverage_json_invalid(self):
         """p3.data.validation.coverage_json_invalid"""
-        json_string = '[{"file": "id", "regions": [["1"]]}]'
+        json_string = '[{"file": "path", "id": "sha", "lines": [["1"]]}]'
         with self.assertRaises(ValueError):
             _validate_coverage_json(json_string)
 
         with self.assertRaises(TypeError):
-            json_object = [{"file": "id", "regions": [[1, 2, 3]]}]
+            json_object = [{"file": "path", "id": "sha", "lines": [["1"]]}]
             _validate_coverage_json(json_object)
 
 

--- a/tests/metrics/test_divergence.py
+++ b/tests/metrics/test_divergence.py
@@ -13,7 +13,7 @@ class TestDivergence(unittest.TestCase):
     """
 
     def test_required_columns(self):
-        """p3.data.divergence.required_columns"""
+        """Check that divergence() validates required columns."""
         df = pd.DataFrame()
         cov = pd.DataFrame()
 
@@ -21,7 +21,7 @@ class TestDivergence(unittest.TestCase):
             divergence(df, cov)
 
     def test_side_effects(self):
-        """p3.data.divergence.side_effects"""
+        """Check that divergence() has no side effects."""
         key = 0
         data = {
             "problem": ["test"] * 2,
@@ -53,7 +53,7 @@ class TestDivergence(unittest.TestCase):
         pd.testing.assert_frame_equal(cov_before, cov_after)
 
     def test_divergence(self):
-        """p3.data.divergence"""
+        """Check that divergence() produces expected results for valid data."""
         data = {
             "problem": ["test"] * 2,
             "platform": ["A", "B"],
@@ -106,7 +106,7 @@ class TestDivergence(unittest.TestCase):
         pd.testing.assert_frame_equal(result, expected_result)
 
     def test_divergence_single(self):
-        """p3.data.divergence.single"""
+        """Check that divergence() does not fail with only one platform."""
         key = 0
         data = {
             "problem": ["test"],
@@ -139,7 +139,7 @@ class TestDivergence(unittest.TestCase):
         pd.testing.assert_frame_equal(result, expected_df)
 
     def test_divergence_duplicate(self):
-        """p3.data.divergence.duplicate"""
+        """Check that divergence() uses both file and id for uniqueness."""
         data = {
             "problem": ["test"] * 2,
             "platform": ["A", "B"],

--- a/tests/metrics/test_divergence.py
+++ b/tests/metrics/test_divergence.py
@@ -148,6 +148,7 @@ class TestDivergence(unittest.TestCase):
         }
         df = pd.DataFrame(data)
 
+        # First file called "foo.cpp" has an id of "0".
         source1_json_string = json.dumps(
             [
                 {
@@ -158,6 +159,8 @@ class TestDivergence(unittest.TestCase):
             ]
         )
 
+        # Second file called "foo.cpp" has a different id ("1").
+        # It should therefore be recognized as a different file.
         source2_json_string = json.dumps(
             [
                 {

--- a/tests/metrics/test_divergence.py
+++ b/tests/metrics/test_divergence.py
@@ -33,10 +33,9 @@ class TestDivergence(unittest.TestCase):
         json_string = json.dumps(
             [
                 {
-                    "file": "0",
-                    "regions": [
-                        [0, 1, 1],
-                    ],
+                    "file": "file.cpp",
+                    "id": "0",
+                    "lines": [0],
                 }
             ]
         )
@@ -66,10 +65,9 @@ class TestDivergence(unittest.TestCase):
         source1_json_string = json.dumps(
             [
                 {
-                    "file": "0",
-                    "regions": [
-                        [0, 10, 10],
-                    ],
+                    "file": "foo.cpp",
+                    "id": "0",
+                    "lines": [[0, 9]],
                 }
             ]
         )
@@ -77,16 +75,14 @@ class TestDivergence(unittest.TestCase):
         source2_json_string = json.dumps(
             [
                 {
-                    "file": "0",
-                    "regions": [
-                        [0, 10, 10],
-                    ],
+                    "file": "foo.cpp",
+                    "id": "0",
+                    "lines": [[0, 9]],
                 },
                 {
-                    "file": "1",
-                    "regions": [
-                        [0, 10, 10],
-                    ],
+                    "file": "bar.cpp",
+                    "id": "1",
+                    "lines": [[0, 9]],
                 },
             ]
         )
@@ -123,10 +119,9 @@ class TestDivergence(unittest.TestCase):
         json_string = json.dumps(
             [
                 {
-                    "file": "0",
-                    "regions": [
-                        [0, 1, 1],
-                    ],
+                    "file": "file.cpp",
+                    "id": "0",
+                    "lines": [0],
                 }
             ]
         )
@@ -142,6 +137,54 @@ class TestDivergence(unittest.TestCase):
         expected_df = pd.DataFrame(expected_data)
 
         pd.testing.assert_frame_equal(result, expected_df)
+
+    def test_divergence_duplicate(self):
+        """p3.data.divergence.duplicate"""
+        data = {
+            "problem": ["test"] * 2,
+            "platform": ["A", "B"],
+            "application": ["latest"] * 2,
+            "coverage_key": ["source1", "source2"],
+        }
+        df = pd.DataFrame(data)
+
+        source1_json_string = json.dumps(
+            [
+                {
+                    "file": "foo.cpp",
+                    "id": "0",
+                    "lines": [[0, 9]],
+                }
+            ]
+        )
+
+        source2_json_string = json.dumps(
+            [
+                {
+                    "file": "foo.cpp",
+                    "id": "1",
+                    "lines": [[0, 9]],
+                },
+            ]
+        )
+
+        cov = pd.DataFrame(
+            {
+                "coverage_key": ["source1", "source2"],
+                "coverage": [source1_json_string, source2_json_string],
+            }
+        )
+
+        result = divergence(df, cov)
+
+        expected_data = {
+            "problem": ["test"],
+            "application": ["latest"],
+            "divergence": [1.0],
+        }
+        expected_result = pd.DataFrame(expected_data)
+
+        pd.testing.assert_frame_equal(result, expected_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Experiments with the old schemas (0.1.0 and 0.2.0) have uncovered two issues:

1) A file hash is not sufficient to identify a file when computing divergence, because a code base may contain duplicates of a file that SHOULD count towards divergence. Accounting for this requires the coverage format to store both the path and a hash.

2) The region format is too closely tied to the operation of specific tools. Each region in the output corresponds to a region of source identified by the producer of the JSON, with no way to recover what the region represents, or which lines within the region are used. As a result, it is impossible touse coverage information from multiple tools (or tool versions).

The new coverage format attempts to address both of these issues by requiring both a file name and some sort of unique ID (in practice, a hash), and storing an explicit list of line numbers.

# Related issues

This is tied to https://github.com/intel/code-base-investigator/issues/72. When we designed the original coverage format, we assumed that CBI's handling of duplicate files was correct and that it would be sufficient to base coverage calculations on files identified only by a hash value.

# Proposed changes

- Move to a new coverage format that requires a filename, unique ID (hash) and a simple list of lines touched.
- Update tests to use the new coverage format.
- Update divergence calculation to accept the new coverage format.

I haven't yet rewritten the documentation, because I want to make sure we agree on the functionality first.
