### PR TITLE
Disabling pre-commit run on `main`

### DIFF
--- a/.github/workflows/run-precommit.yml
+++ b/.github/workflows/run-precommit.yml
@@ -1,8 +1,6 @@
 name: Run pre-commit hooks
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
The CI pre-commit action is intended primarily for code review based on how it's written (i.e. using Github SHA refs for diffs) and does not work for `main` branch.

# Related issues

N/A

# Proposed changes

List out&mdash;with high level descriptions&mdash;what the commits
within this PR do:

- Disable pre-commit workflow trigger for code pushed to `main`
