### PR TITLE
Remove flake8-black from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,6 @@ repos:
           [
             flake8-debugger,
             flake8-use-fstring,
-            flake8-black,
           ]
         args:
           [


### PR DESCRIPTION
We run black as part of pre-commit already, so don't need to run flake8-black.

Additionally, since black and flake8-black look for configuration information in different places, running both can lead to disagreement between the tools.

# Related issues

Currently blocking #18.

# Proposed changes

- Remove `flake8-black` from the `flake8` configuration, bringing things closer in line with the CBI pre-commit configuration.

---

@laserkelvin: Sorry for not catching this during review.  I know we discussed this, but I somehow missed it in the diff.