### PR TITLE
Update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: 🐛 Bug report
 description: Create a report to help us improve
 labels: bug
-title: "[Bug]: "
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: 🚀 Feature request
 description: Suggest new functionality
 labels: enhancement
-title: "[Feature request]: "
 body:
   - type: textarea
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,23 @@
 # Related issues
 
-If applicable:
+<!--
+If applicable, provide a list of related issues here.
 
-Closes/Fixes/Addresses #<issue_number>
+Consider using a keyword like "closes" to automatically link this pull request
+to any issues that should be automatically closed when this pull request is
+merged. See the GitHub documentation for more information:
+https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
 
-If not applicable: write "N/A".
+If not applicable, write "N/A".
+-->
 
 # Proposed changes
 
-List out&mdash;with high level descriptions&mdash;what the commits
-within this PR do:
+<!--
+List out, with high level descriptions, what the commits within this pull
+request do.
+-->
 
-- 
+-
 -
 -


### PR DESCRIPTION
# Related issues

Closes #29. 

# Proposed changes

- Remove [Bug] and [Feature request] tags from issue templates.
- Move instructions into comments in pull request template.
