### PR TITLE
Raise exception for cascades with > 26 platforms

### DIFF
--- a/p3/plot/backend/matplotlib.py
+++ b/p3/plot/backend/matplotlib.py
@@ -241,6 +241,11 @@ class CascadePlot(CascadePlot):
         plat_colors = self.__get_colors(platforms, plat_style.colors)
 
         # Choose labels for each platform
+        if len(platforms) > len(string.ascii_uppercase):
+            raise RuntimeError(
+                "The number of platforms supported by cascade plots is "
+                + f"currently limited to {len(string.ascii_uppercase)}.",
+            )
         plat_labels = dict(zip(platforms, string.ascii_uppercase))
 
         # Plot the efficiency cascade in the top-left (0, 0)


### PR DESCRIPTION
The platform chart beneath the cascade uses uppercase letters (A-Z) to label each platform. Cascade plots with more than 26 platforms run out of labels.

This is a short term fix to generate a useful error message while we work on a more robust way of assigning platform labels.

# Related issues

Short-term fix for #39. 

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Raise exception for cascades with > 26 platforms.
