### PR TITLE
Raise exception if # applications > # markers

### DIFF
--- a/p3/plot/backend/matplotlib.py
+++ b/p3/plot/backend/matplotlib.py
@@ -235,6 +235,12 @@ class CascadePlot(CascadePlot):
         markers = app_style.markers
         if not isinstance(markers, (list, tuple)):
             raise ValueError("Unsupported type provided for app_markers")
+        if len(applications) > len(markers):
+            raise RuntimeError(
+                f"The number of applications ({len(applications)}) is greater "
+                f"than the number of markers ({len(markers)}). "
+                + "Please adjust the ApplicationStyle.",
+            )
         app_markers = {app: color for app, color in zip(applications, markers)}
 
         # Choose colors for each platform
@@ -566,6 +572,12 @@ class NavChart(NavChart):
         markers = style.markers
         if not isinstance(markers, (list, tuple)):
             raise ValueError("Unsupported type provided for app_markers")
+        if len(applications) > len(markers):
+            raise RuntimeError(
+                f"The number of applications ({len(applications)}) is greater "
+                f"than the number of markers ({len(markers)}). "
+                + "Please adjust the ApplicationStyle.",
+            )
         app_markers = {
             app: marker for app, marker in zip(applications, markers)
         }


### PR DESCRIPTION
The number of applications could exceed the number of markers because:
- We default to matplotlib's list of 16 "filled" markers; or
- A user-provided marker list is too small.

In both cases, an ApplicationStyle can be used to increase the number of markers.

This change effects both Cascade and NavChart plots.

# Related issues

Closes #42.

# Proposed changes

- Raise an exception if the number of applications is greater than the number of markers.
