### PR TITLE
Add "date" to application_efficiency filter

### DIFF
--- a/p3/metrics/_efficiency.py
+++ b/p3/metrics/_efficiency.py
@@ -50,7 +50,7 @@ def application_efficiency(df, foms="lower"):
     if foms not in ["lower", "higher"]:
         raise ValueError("FOM interpretation must be 'lower' or 'higher'")
 
-    result = df.filter(required_columns)
+    result = df.filter(required_columns + ["date"])
 
     # Identify the best FOM for each (problem, platform) triple
     key = ["problem", "platform"]


### PR DESCRIPTION
"date" is named as a column with special meaning in some parts of the documentation. It's therefore potentially surprising if calling application_efficiency can result in the "date" field being stripped.

# Related issues

N/A

# Proposed changes

- Add "date" to the `filter()` call in `application_efficiency`, so the column is passed through (if it exists).
