### PR TITLE
Reject duplicate results when handling efficiencies

### DIFF
--- a/p3/metrics/_pp.py
+++ b/p3/metrics/_pp.py
@@ -120,7 +120,7 @@ def pp(df):
     # Calculate performance portability for both types of efficiency
     key = ["problem", "application"]
     df[efficiencies] = df[efficiencies].astype(float).fillna(0.0)
-    groups = df[key + efficiencies].groupby(key)
+    groups = df[key + efficiencies].groupby(key, sort=False)
     pp = groups.agg(_hmean)
     pp.reset_index(inplace=True)
     for eff in efficiencies:

--- a/p3/metrics/_pp.py
+++ b/p3/metrics/_pp.py
@@ -61,7 +61,9 @@ def pp(df):
     ------
     ValueError
         If any of the required columns are missing from `df`.
-        If any (application, platform) pair has multiple efficiency values.
+        If any (application, platform) pair has multiple efficiency values,
+        since the pp metric calculation for each application expects one
+        efficiency value per platform.
 
     TypeError
         If any of the values in the efficiency column(s) are non-numeric.

--- a/p3/plot/_cascade.py
+++ b/p3/plot/_cascade.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2020 Performance Portability authors
 # SPDX-License-Identifier: MIT
 
-from p3._utils import _require_columns
+from p3._utils import _require_columns, _require_numeric
 
 
 def cascade(df, eff=None, size=None, **kwargs):
@@ -86,16 +86,40 @@ def cascade(df, eff=None, size=None, **kwargs):
             "Handling multiple problems is currently not implemented.",
         )
 
+    # Choose efficiency column based on eff parameter and available columns
+    efficiency_columns = []
+
+    for column in ["app eff", "arch eff"]:
+        if column in df:
+            efficiency_columns.append(column)
+    if len(efficiency_columns) == 0:
+        msg = (
+            "DataFrame does not contain an 'app eff' or 'arch eff' ",
+            "column.",
+        )
+        raise ValueError(msg)
+
+    if eff is None:
+        eff_column = efficiency_columns[0]
+    else:
+        if eff not in ["app", "arch"]:
+            raise ValueError("'eff' must be 'app' or 'arch'.")
+        eff_column = eff + " eff"
+        if eff_column not in df:
+            msg = "DataFrame does not contain an '%s' column."
+            raise ValueError(msg % (eff_column))
+    _require_numeric(df, [eff_column])
+
     kwargs.setdefault("backend", "matplotlib")
     backend = kwargs["backend"]
     if backend == "matplotlib":
         from p3.plot.backend.matplotlib import CascadePlot
 
-        return CascadePlot(df, eff, size, **kwargs)
+        return CascadePlot(df, eff_column, size, **kwargs)
     elif backend == "pgfplots":
         from p3.plot.backend.pgfplots import CascadePlot
 
-        return CascadePlot(df, eff, size, **kwargs)
+        return CascadePlot(df, eff_column, size, **kwargs)
     else:
         raise ValueError(
             "'backend' must be one of the supported backends: ",

--- a/p3/plot/_cascade.py
+++ b/p3/plot/_cascade.py
@@ -75,7 +75,9 @@ def cascade(df, eff=None, size=None, **kwargs):
     ValueError
         If any of the required columns are missing from `df`.
         If `eff` is set to any value other than "app" or "arch".
-        If any (application, platform) pair has multiple efficiency values.
+        If any (application, platform) pair has multiple efficiency values,
+        since the plot shows only one efficiency value per (application,
+        platform) combination.
 
     TypeError
         If any of the values in the efficiency column(s) is non-numeric.

--- a/p3/plot/_cascade.py
+++ b/p3/plot/_cascade.py
@@ -75,6 +75,7 @@ def cascade(df, eff=None, size=None, **kwargs):
     ValueError
         If any of the required columns are missing from `df`.
         If `eff` is set to any value other than "app" or "arch".
+        If any (application, platform) pair has multiple efficiency values.
 
     TypeError
         If any of the values in the efficiency column(s) is non-numeric.
@@ -109,6 +110,14 @@ def cascade(df, eff=None, size=None, **kwargs):
             msg = "DataFrame does not contain an '%s' column."
             raise ValueError(msg % (eff_column))
     _require_numeric(df, [eff_column])
+
+    # Check there is only one entry per (application, platform) pair.
+    grouped = df.groupby(["platform", "application"])
+    if not (grouped[eff_column].nunique() == 1).all():
+        raise ValueError(
+            "Each (application, platform) pair must be associated with "
+            + "exactly one efficiency value.",
+        )
 
     kwargs.setdefault("backend", "matplotlib")
     backend = kwargs["backend"]

--- a/p3/plot/backend/matplotlib.py
+++ b/p3/plot/backend/matplotlib.py
@@ -92,7 +92,15 @@ class CascadePlot(CascadePlot):
     Cascade plot object for :py:mod:`matplotlib`.
     """
 
-    def __init__(self, df, eff=None, size=None, fig=None, axes=None, **kwargs):
+    def __init__(
+        self,
+        df,
+        eff_column,
+        size=None,
+        fig=None,
+        axes=None,
+        **kwargs,
+    ):
         super().__init__("matplotlib")
 
         kwargs.setdefault("platform_legend", Legend())
@@ -118,31 +126,6 @@ class CascadePlot(CascadePlot):
                 matplotlib.markers.MarkerStyle,
                 "filled_markers",
             )
-
-        # Choose the efficiency column based on eff parameter and available
-        # columns
-        efficiency_columns = []
-
-        for column in ["app eff", "arch eff"]:
-            if column in df:
-                efficiency_columns.append(column)
-        if len(efficiency_columns) == 0:
-            msg = (
-                "DataFrame does not contain an 'app eff' or 'arch eff' ",
-                "column.",
-            )
-            raise ValueError(msg)
-
-        if eff is None:
-            eff_column = efficiency_columns[0]
-        else:
-            if eff not in ["app", "arch"]:
-                raise ValueError("'eff' must be 'app' or 'arch'.")
-            eff_column = eff + " eff"
-            if eff_column not in df:
-                msg = "DataFrame does not contain an '%s' column."
-                raise ValueError(msg % (eff_column))
-        _require_numeric(df, [eff_column])
 
         # If the size is unset, default to 6 x 5
         if not size:

--- a/p3/plot/backend/matplotlib.py
+++ b/p3/plot/backend/matplotlib.py
@@ -131,12 +131,6 @@ class CascadePlot(CascadePlot):
         if not size:
             size = (6, 5)
 
-        # Keep only the most efficient (application, platform) results.
-        key = ["problem", "platform", "application"]
-        groups = df[key + [eff_column]].groupby(key)
-        df = groups.agg("max")
-        df.reset_index(inplace=True)
-
         platforms = df["platform"].unique()
         applications = df["application"].unique()
 

--- a/p3/plot/backend/pgfplots.py
+++ b/p3/plot/backend/pgfplots.py
@@ -84,7 +84,7 @@ class CascadePlot(CascadePlot):
     Cascade plot object for :py:mod:`pgfplots`.
     """
 
-    def __init__(self, df, eff=None, size=None, stream=None, **kwargs):
+    def __init__(self, df, eff_column, size=None, stream=None, **kwargs):
         super().__init__("pgfplots")
 
         default_markers = _pgfplots_markers
@@ -104,30 +104,6 @@ class CascadePlot(CascadePlot):
             app_style.colors = getattr(plt.cm, "tab10")
         if not app_style.markers:
             app_style.markers = default_markers
-
-        # Choose the efficiency column based on eff parameter and available
-        # columns
-        efficiency_columns = []
-        for column in ["app eff", "arch eff"]:
-            if column in df:
-                efficiency_columns.append(column)
-        if len(efficiency_columns) == 0:
-            msg = (
-                "DataFrame does not contain an 'app eff' or 'arch eff' ",
-                "column.",
-            )
-            raise ValueError(msg)
-
-        if eff is None:
-            eff_column = efficiency_columns[0]
-        else:
-            if eff not in ["app", "arch"]:
-                raise ValueError("'eff' must be 'app' or 'arch'.")
-            eff_column = eff + " eff"
-            if eff_column not in df:
-                msg = "DataFrame does not contain an '%s' column."
-                raise ValueError(msg % (eff_column))
-        _require_numeric(df, [eff_column])
 
         # If the size is unset, default to 200pt x 200pt, otherwise set size
         plotwidth = "200pt"

--- a/p3/plot/backend/pgfplots.py
+++ b/p3/plot/backend/pgfplots.py
@@ -112,12 +112,6 @@ class CascadePlot(CascadePlot):
             plotwidth = size[0]
             plotheight = size[1]
 
-        # Keep only the most efficient (application, platform) results.
-        key = ["problem", "platform", "application"]
-        groups = df[key + [eff_column]].groupby(key)
-        df = groups.agg("max")
-        df.reset_index(inplace=True)
-
         platforms = df["platform"].unique()
         applications = df["application"].unique()
 

--- a/tests/metrics/test_pp.py
+++ b/tests/metrics/test_pp.py
@@ -92,8 +92,8 @@ class TestPP(unittest.TestCase):
 
         expected_data = {
             "problem": ["test"] * 3,
-            "application": ["best", "dummy", "latest"],
-            "app pp": [1.0, 0.0, 0.4878],
+            "application": ["latest", "best", "dummy"],
+            "app pp": [0.4878, 1.0, 0.0],
             "arch pp": [0.0] * 3,
         }
         expected_df = pd.DataFrame(expected_data)

--- a/tests/metrics/test_pp.py
+++ b/tests/metrics/test_pp.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: MIT
 
-import pandas as pd
-from p3.metrics import pp
 import unittest
+
+import pandas as pd
+
+from p3.metrics import pp
 
 
 class TestPP(unittest.TestCase):
@@ -135,7 +137,7 @@ class TestPP(unittest.TestCase):
         pd.testing.assert_frame_equal(result, expected_df)
 
     def test_pp_duplicates(self):
-        """p3.data.pp.duplicates"""
+        """Check that duplicates are reported as an error"""
 
         # Regression for case with duplicate result
         data = {
@@ -148,17 +150,8 @@ class TestPP(unittest.TestCase):
         }
         df = pd.DataFrame(data)
 
-        result = pp(df)
-
-        expected_data = {
-            "problem": ["test"],
-            "application": ["latest"],
-            "app pp": [1.0],
-            "arch pp": [0.5],
-        }
-        expected_df = pd.DataFrame(expected_data)
-
-        pd.testing.assert_frame_equal(result, expected_df)
+        with self.assertRaises(ValueError):
+            _ = pp(df)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Removing data from a user-supplied DataFrame might impact certain properties of the data (e.g., the order in which applications, platforms, and/or problems appear).

Rather than complicate our implementation with workarounds that might not address every possible use-case, we can simply detect and reject problematic data.

# Related issues

This effectively reverts #22.  It's an alternative solution to the one proposed in #63. 

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Reject duplicate (application, platform) pairs when calculating PP and plotting cascades.
- Prevent `pp` from sorting implicitly during its `groupby` operation.
- Update tests to match new expected behavior.

---

The upshot of the changes here is intended to be:

- For simple datasets with no duplicate results, there is no change in behavior.
- For complex datasets with duplicate results (which may occur after projection), we throw a `ValueError`.
- All of our calculation and plotting functions should now respect the order of the data given to them, so the user regains the ability to control the order of applications and platforms in the legend simply by sorting their data.

In my own offline testing of complex P3 workflows, I've found that I need to insert an additional line to prepare data the way I typically want it to be plotted:
```python
eff_df = p3.metrics.application_efficiency(projected_df, foms="higher")
eff_df = eff_df.sort_values("app eff").drop_duplicates(["application", "platform"], keep="last").sort_index()
cascade = p3.plot.cascade(eff_df)
```

I don't think this is *too* bad, and it only shows up in complicated cases.  If we wanted to simplify this workflow, we could consider introducing something like:
```python
eff_df = p3.metrics.application_efficiency(projected_df, foms="higher", keep="best") # or keep="all", keep="latest"
cascade = p3.plot.cascade(eff_df)
```

...but I'd want to explore that separately, to make sure that we design and test it properly.