### PR TITLE
Fix navchart column

### DIFF
--- a/p3analysis/plot/backend/matplotlib.py
+++ b/p3analysis/plot/backend/matplotlib.py
@@ -467,7 +467,7 @@ class NavChart(NavChart):
         else:
             if eff not in ["app", "arch"]:
                 raise ValueError("'eff' must be 'app' or 'arch'.")
-            pp_column = eff + " eff"
+            pp_column = eff + " pp"
             if pp_column not in pp:
                 msg = "DataFrame does not contain an '%s' column."
                 raise ValueError(msg % (pp_column))

--- a/p3analysis/plot/backend/pgfplots.py
+++ b/p3analysis/plot/backend/pgfplots.py
@@ -289,7 +289,7 @@ class NavChart(NavChart):
         else:
             if eff not in ["app", "arch"]:
                 raise ValueError("'eff' must be 'app' or 'arch'.")
-            pp_column = eff + " eff"
+            pp_column = eff + " pp"
             if pp_column not in pp:
                 msg = "DataFrame does not contain an '%s' column."
                 raise ValueError(msg % (pp_column))

--- a/tests/plot/test_navchart.py
+++ b/tests/plot/test_navchart.py
@@ -34,6 +34,19 @@ class TestNavchart(unittest.TestCase):
         with self.assertRaises(ValueError):
             navchart(pp, cd, eff="invalid")
 
+        pp = pd.DataFrame({
+            "problem": ["problem"],
+            "platform": ["platform"],
+            "application": ["application"],
+            "app pp": [1.0],
+        })
+        cd = pd.DataFrame({
+            "problem": ["problem"],
+            "application": ["application"],
+            "divergence": [0.0],
+        })
+        navchart(pp, cd)
+
     def test_options(self):
         """p3analysis.plot.navchart.options"""
 


### PR DESCRIPTION
Due to a copy-paste error, NavChart was looking for columns with the "eff" suffix instead of columns with the "pp" suffix.

# Related issues

N/A

# Proposed changes

- Check for the correct columns in both matplotlib and pgfplots backends.
- Add a simple regression test to make sure we don't accidentally break this again.
