### PR TITLE
Move plot styling options out of kwargs

### DIFF
--- a/p3analysis/plot/_cascade.py
+++ b/p3analysis/plot/_cascade.py
@@ -6,6 +6,8 @@
 # Copyright (c) 2020 Performance Portability authors
 # SPDX-License-Identifier: MIT
 
+import copy
+
 from p3analysis._utils import _require_columns, _require_numeric
 
 
@@ -125,7 +127,7 @@ def cascade(
 
     # Add styling options, if provided, into kwargs.
     # Permits different backends to set different defaults.
-    kwargs = dict(kwargs)
+    kwargs = copy.deepcopy(kwargs)
     if platform_legend:
         kwargs["platform_legend"] = platform_legend
     if application_legend:

--- a/p3analysis/plot/_cascade.py
+++ b/p3analysis/plot/_cascade.py
@@ -9,7 +9,18 @@
 from p3analysis._utils import _require_columns, _require_numeric
 
 
-def cascade(df, eff=None, size=None, **kwargs):
+def cascade(
+    df,
+    eff=None,
+    *,
+    size=None,
+    platform_legend=None,
+    application_legend=None,
+    platform_style=None,
+    application_style=None,
+    backend="matplotlib",
+    **kwargs,
+):
     """
     Plot a `cascade`_ summarizing the efficiency and performance
     portability of each application in a DataFrame, highlighting
@@ -36,33 +47,24 @@ def cascade(df, eff=None, size=None, **kwargs):
         backend the size controls only the top left plot, where the default
         is ("200pt", "200pt")
 
+    platform_legend: p3analysis.plot.Legend, optional
+        Styling options for platform legend.
+
+    application_legend: p3analysis.plot.Legend, optional
+        Styling options for application legend.
+
+    platform_style: p3analysis.plot.PlatformStyle, optional
+        Styling options for platforms.
+
+    application_style: p3analysis.plot.ApplicationStyle, optional
+        Styling options for applications.
+
+    backend: str, {"matplotlib", "pgfplots"}, default: "matplotlib"
+        Backend to use to produce the plot.
+
     **kwargs: properties, optional
-        `kwargs` are used to specify properties that control various styling
-        options (e.g. colors and markers).
-
-        .. list-table:: Properties
-            :widths: 10, 20, 18
-            :header-rows: 1
-
-            * - Property
-              - Type
-              - Description
-
-            * - `platform_legend`
-              - p3analysis.plot.Legend
-              - Styling options for platform legend.
-
-            * - `application_legend`
-              - p3analysis.plot.Legend
-              - Styling options for application legend.
-
-            * - `platform_style`
-              - p3analysis.plot.PlatformStyle
-              - Styling options for platforms.
-
-            * - `application_style`
-              - p3analysis.plot.ApplicationStyle
-              - Styling options for applications.
+        `kwargs` are used to specify properties that control various
+        backend-specific plotting options.
 
     Returns
     -------
@@ -121,8 +123,18 @@ def cascade(df, eff=None, size=None, **kwargs):
             + "exactly one efficiency value.",
         )
 
-    kwargs.setdefault("backend", "matplotlib")
-    backend = kwargs["backend"]
+    # Add styling options, if provided, into kwargs.
+    # Permits different backends to set different defaults.
+    kwargs = dict(kwargs)
+    if platform_legend:
+        kwargs["platform_legend"] = platform_legend
+    if application_legend:
+        kwargs["application_legend"] = application_legend
+    if platform_style:
+        kwargs["platform_style"] = platform_style
+    if application_style:
+        kwargs["application_style"] = application_style
+
     if backend == "matplotlib":
         from p3analysis.plot.backend.matplotlib import CascadePlot
 

--- a/p3analysis/plot/_navchart.py
+++ b/p3analysis/plot/_navchart.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: MIT
 
+import copy
+
 from p3analysis._utils import _require_columns, _require_numeric
 
 
@@ -93,7 +95,7 @@ def navchart(
 
     # Add styling options, if provided, into kwargs.
     # Permits different backends to set different defaults.
-    kwargs = dict(kwargs)
+    kwargs = copy.deepcopy(kwargs)
     if legend:
         kwargs["legend"] = legend
     if style:

--- a/p3analysis/plot/_navchart.py
+++ b/p3analysis/plot/_navchart.py
@@ -4,7 +4,18 @@
 from p3analysis._utils import _require_columns, _require_numeric
 
 
-def navchart(pp, cd, eff=None, size=None, goal=None, **kwargs):
+def navchart(
+    pp,
+    cd,
+    eff=None,
+    *,
+    size=None,
+    goal=None,
+    legend=None,
+    style=None,
+    backend="matplotlib",
+    **kwargs,
+):
     """
     Plot a `navigation chart`_ showing the performance portability and code
     convergence of each application in a DataFrame. The chart highlights the
@@ -41,25 +52,18 @@ def navchart(pp, cd, eff=None, size=None, goal=None, **kwargs):
         User-defined goal, expressed as (convergence, portability).
         The region between this point and (1, 1) will be highlighted.
 
+    legend: p3analysis.plot.Legend, optional
+        Styling options for platform legend.
+
+    style: p3analysis.plot.ApplicationStyle, optional
+        Styling options for applications.
+
+    backend: str, {"matplotlib", "pgfplots"}, default: "matplotlib"
+        Backend to use to produce the plot.
+
     **kwargs: properties, optional
-        `kwargs` are used to specify properties that control various styling
-        options (e.g. colors and markers).
-
-        .. list-table:: Properties
-            :widths: 10, 20, 18
-            :header-rows: 1
-
-            * - Property
-              - Type
-              - Description
-
-            * - `legend`
-              - p3analysis.plot.Legend
-              - Styling options for platform legend.
-
-            * - `style`
-              - p3analysis.plot.ApplicationStyle
-              - Styling options for applications.
+        `kwargs` are used to specify properties that control various
+        backend-specific plotting options.
 
     Returns
     -------
@@ -87,8 +91,14 @@ def navchart(pp, cd, eff=None, size=None, goal=None, **kwargs):
             "Handling multiple problems is currently not implemented.",
         )
 
-    kwargs.setdefault("backend", "matplotlib")
-    backend = kwargs["backend"]
+    # Add styling options, if provided, into kwargs.
+    # Permits different backends to set different defaults.
+    kwargs = dict(kwargs)
+    if legend:
+        kwargs["legend"] = legend
+    if style:
+        kwargs["style"] = style
+
     if backend == "matplotlib":
         from p3analysis.plot.backend.matplotlib import NavChart
 


### PR DESCRIPTION
Before introducing classes like `ApplicationStyle`, passing all styling options via `kwargs` made sense. Now that there are effectively separate `kwargs` lists for different aspects of the plot, those options should be exposed as part of the interface.

# Related issues

Closes #46.

# Proposed changes

- Moves styling options out of `kwargs`.
- Adds an `*` to `cascade` and `navchart` to separate positional arguments from keyword arguments.
- Adds documentation for "backend" option that was previously missing.

---

While working on this I realized an advantage of the `matplotlib`-style list of `kwargs` that I hadn't noticed before.  With `kwargs`, it is very easy to define shorthands because everything is just a key in a dictionary (e.g., `linestyle` and `ls` refer to the same option).

We should be cognizant of the fact that documenting options like `application_style` as part of the interface may make it harder to define such shorthands.  We might want to adopt shorter names now (e.g., `app_style`) or maybe find a way to have consistent argument names across `cascade` and `navchart` (e.g., `style=(PlatformStyle(...), ApplicationStyle(...))`)?

I think we can address this in a future PR, but I'm interested in what you think @swright87 and @laserkelvin.

