### PR TITLE
Improve handling of large cascade plots

### DIFF
--- a/p3analysis/plot/backend/__init__.py
+++ b/p3analysis/plot/backend/__init__.py
@@ -10,6 +10,8 @@ Contains backend-specific interfaces for customizing plots.
    <https://github.com/intel/p3-analysis-library/issues/new/choose>`_.
 """
 
+import string
+
 __all__ = [
     "Plot",
     "CascadePlot",
@@ -51,3 +53,18 @@ class NavChart(Plot):
 
     def __init__(self, backend):
         super().__init__(backend)
+
+
+def _get_platform_labels(platforms: list[str]) -> dict[str, str]:
+    """
+    Returns
+    -------
+    dict[str, str]:
+        A mapping from platform names to unique labels.
+    """
+    if len(platforms) > len(string.ascii_uppercase):
+        raise RuntimeError(
+            "The number of platforms supported by cascade plots is "
+            + f"currently limited to {len(string.ascii_uppercase)}.",
+        )
+    return dict(zip(platforms, string.ascii_uppercase))

--- a/p3analysis/plot/backend/__init__.py
+++ b/p3analysis/plot/backend/__init__.py
@@ -58,6 +58,11 @@ class NavChart(Plot):
 
 def _get_platform_labels(platforms: list[str]) -> dict[str, str]:
     """
+    Parameters
+    ----------
+    platforms : list[str]
+        A list of platform names to associate with labels.
+
     Returns
     -------
     dict[str, str]:

--- a/p3analysis/plot/backend/__init__.py
+++ b/p3analysis/plot/backend/__init__.py
@@ -10,6 +10,7 @@ Contains backend-specific interfaces for customizing plots.
    <https://github.com/intel/p3-analysis-library/issues/new/choose>`_.
 """
 
+import itertools
 import string
 
 __all__ = [
@@ -62,9 +63,15 @@ def _get_platform_labels(platforms: list[str]) -> dict[str, str]:
     dict[str, str]:
         A mapping from platform names to unique labels.
     """
-    if len(platforms) > len(string.ascii_uppercase):
+    if len(platforms) <= len(string.ascii_uppercase):
+        labels = string.ascii_uppercase
+    elif len(platforms) <= len(string.ascii_uppercase) ** 2:
+        labels = []
+        for x, y in itertools.product(string.ascii_uppercase, repeat=2):
+            labels.append(f"{x}{y}")
+    else:
         raise RuntimeError(
             "The number of platforms supported by cascade plots is "
-            + f"currently limited to {len(string.ascii_uppercase)}.",
+            + f"currently limited to {len(string.ascii_uppercase)**2}.",
         )
-    return dict(zip(platforms, string.ascii_uppercase))
+    return dict(zip(platforms, labels))

--- a/p3analysis/plot/backend/matplotlib.py
+++ b/p3analysis/plot/backend/matplotlib.py
@@ -125,12 +125,15 @@ class CascadePlot(CascadePlot):
                 "filled_markers",
             )
 
-        # If the size is unset, default to 6 x 5
-        if not size:
-            size = (6, 5)
-
         platforms = df["platform"].unique()
         applications = df["application"].unique()
+
+        # If the size is unset, try to pick a sensible default.
+        if not size:
+            if len(platforms) <= 26:
+                size = (6, 5)
+            else:
+                size = (12, 10)
 
         # Create a 2x2 grid of subplots sharing axes
         fig = plt.figure(figsize=size)

--- a/p3analysis/plot/backend/matplotlib.py
+++ b/p3analysis/plot/backend/matplotlib.py
@@ -55,6 +55,10 @@ class _PlatformLegendHandler(matplotlib.legend_handler.HandlerBase):
     ):
         artist = []
 
+        # Make adjustments for large numbers of platforms.
+        if len(self.labels) > 26:
+            width *= 1.5
+
         # Draw a box using the platform's assigned color
         name = orig_handle.get_label()
         color = self.colors[name]

--- a/p3analysis/plot/backend/matplotlib.py
+++ b/p3analysis/plot/backend/matplotlib.py
@@ -5,8 +5,6 @@ Contains objects for interacting with plots produced using the
 :py:mod:`matplotlib` backend.
 """
 
-import string
-
 import matplotlib
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
@@ -17,7 +15,7 @@ from matplotlib.path import Path
 import p3analysis.metrics
 from p3analysis._utils import _require_numeric
 from p3analysis.plot._common import ApplicationStyle, Legend, PlatformStyle
-from p3analysis.plot.backend import CascadePlot, NavChart
+from p3analysis.plot.backend import CascadePlot, NavChart, _get_platform_labels
 
 
 def _get_colors(applications, kwarg):
@@ -168,12 +166,7 @@ class CascadePlot(CascadePlot):
         plat_colors = _get_colors(platforms, plat_style.colors)
 
         # Choose labels for each platform
-        if len(platforms) > len(string.ascii_uppercase):
-            raise RuntimeError(
-                "The number of platforms supported by cascade plots is "
-                + f"currently limited to {len(string.ascii_uppercase)}.",
-            )
-        plat_labels = dict(zip(platforms, string.ascii_uppercase))
+        plat_labels = _get_platform_labels(platforms)
 
         # Plot the efficiency cascade in the top-left (0, 0)
         app_handles = self.__efficiency_cascade(

--- a/p3analysis/plot/backend/pgfplots.py
+++ b/p3analysis/plot/backend/pgfplots.py
@@ -5,8 +5,6 @@ Contains objects for interacting with plots produced using the
 :py:mod:`pgfplots` backend.
 """
 
-import string
-
 import jinja2
 import matplotlib
 import matplotlib.pyplot as plt
@@ -16,7 +14,7 @@ import pandas as pd
 import p3analysis.metrics
 from p3analysis._utils import _require_numeric
 from p3analysis.plot._common import ApplicationStyle, Legend, PlatformStyle
-from p3analysis.plot.backend import CascadePlot, NavChart
+from p3analysis.plot.backend import CascadePlot, NavChart, _get_platform_labels
 
 # Define 19 default markers for LaTeX plots
 _pgfplots_markers = [
@@ -139,7 +137,7 @@ class CascadePlot(CascadePlot):
             ).strip("()")
 
         # Build a dictionary of platforms to labels
-        plat_labels = dict(zip(platforms, string.ascii_uppercase))
+        plat_labels = _get_platform_labels(platforms)
 
         # Choose colors for each platform and then convert the dictionary to
         # RGB colors using the platform labels
@@ -161,9 +159,6 @@ class CascadePlot(CascadePlot):
             app_line_specs[
                 app
             ] = f"{app_to_tex_name[app]}, thick, solid, mark={mark}"
-
-        # Choose labels for each platform
-        plat_labels = dict(zip(platforms, string.ascii_uppercase))
 
         # Set the number of rows in the platform key (if set)
         # NOTE: This is different to matplotlib because PGF plots uses columns,


### PR DESCRIPTION
# Related issues

Closes #39.

# Proposed changes

- Switch to AA, AB, AC, AD labels for very large plots, increasing the upper limit to 676 platforms.
- Tweak default plotting parameters for large plots to make them readable.

---

Clearly 676 platforms is too many, and I don't think anybody will ever want to produce such a large plot.  But this change allows us to handle plots with many platforms without crashing.  There will still be cases where the plot is unreadable, but the user can work around that by increasing the plot size.

Here's an example of 30 platforms, where the default is now readable:

![30](https://github.com/user-attachments/assets/d29f222b-638f-4945-9e29-19363b29d330)

By the time we hit 50 platforms, things are pretty squished:

![50](https://github.com/user-attachments/assets/923cc2b8-837c-4968-9110-78f11c79320c)

I'm pretty happy with this as a fix for now, because most studies I've seen in real life use somewhere between 1-10 platforms.  Fixing this for the general case will require some assistance from somebody who has a better grasp of how things like font sizes and plot sizes are connected in matplotlib.
