### PR TITLE
Permit coverage JSON strings and objects

### DIFF
--- a/p3analysis/data/_validation.py
+++ b/p3analysis/data/_validation.py
@@ -3,36 +3,34 @@
 
 import json
 import pkgutil
+from typing import Any
 
 import jsonschema
 
 
-def _validate_coverage_json(json_string: str) -> object:
+def _validate_coverage_json(json_data: Any) -> object:
     """
-    Validate coverage JSON string against schema.
+    Validate coverage JSON against schema.
 
     Parameters
     ----------
-    json_string : String
-        The JSON string to validate.
+    json_data : Any
+        The JSON string or object to validate.
 
     Returns
     -------
     Object
-        A Python object corresponding to the JSON string.
+        A Python object corresponding to the JSON provided.
 
     Raises
     ------
     ValueError
-        If the JSON string fails to validate.
-
-    TypeError
-        If the JSON string is not a string.
+        If the JSON fails to validate.
     """
-    if not isinstance(json_string, str):
-        raise TypeError("Coverage must be a JSON string.")
-
-    instance = json.loads(json_string)
+    if isinstance(json_data, str):
+        instance = json.loads(json_data)
+    else:
+        instance = json_data
 
     schema_string = pkgutil.get_data(__name__, "coverage.schema")
     if not schema_string:
@@ -44,7 +42,7 @@ def _validate_coverage_json(json_string: str) -> object:
     try:
         jsonschema.validate(instance=instance, schema=schema)
     except jsonschema.exceptions.ValidationError:
-        msg = "Coverage string failed schema validation"
+        msg = "Coverage data failed schema validation"
         raise ValueError(msg)
     except jsonschema.exceptions.SchemaError:
         msg = "coverage.schema is not a valid schema"

--- a/p3analysis/data/_validation.py
+++ b/p3analysis/data/_validation.py
@@ -3,18 +3,17 @@
 
 import json
 import pkgutil
-from typing import Any
 
 import jsonschema
 
 
-def _validate_coverage_json(json_data: Any) -> object:
+def _validate_coverage_json(json_data: str | dict | list) -> object:
     """
     Validate coverage JSON against schema.
 
     Parameters
     ----------
-    json_data : Any
+    json_data : str | dict | list
         The JSON string or object to validate.
 
     Returns
@@ -26,11 +25,16 @@ def _validate_coverage_json(json_data: Any) -> object:
     ------
     ValueError
         If the JSON fails to validate.
+
+    TypeError
+        If the JSON data is not a string, dict or list.
     """
     if isinstance(json_data, str):
         instance = json.loads(json_data)
-    else:
+    elif isinstance(json_data, dict | list):
         instance = json_data
+    else:
+        raise TypeError("JSON data must be a string, dict, or list")
 
     schema_string = pkgutil.get_data(__name__, "coverage.schema")
     if not schema_string:

--- a/tests/data/test_validation.py
+++ b/tests/data/test_validation.py
@@ -33,6 +33,13 @@ class TestValidation(unittest.TestCase):
             json_object = [{"file": "path", "id": "sha", "used_lines": [["1"]], "unused_lines": []}]
             _validate_coverage_json(json_object)
 
+        # Check that we only accept strings, lists and dicts.
+        with self.assertRaises(TypeError):
+            _validate_coverage_json(3)
+
+        # Check that we rejects dicts based on schema rather than type.
+        with self.assertRaises(ValueError):
+            _validate_coverage_json({})
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/data/test_validation.py
+++ b/tests/data/test_validation.py
@@ -24,7 +24,7 @@ class TestValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             _validate_coverage_json(json_string)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             json_object = [{"file": "path", "id": "sha", "used_lines": [["1"]], "unused_lines": []}]
             _validate_coverage_json(json_object)
 

--- a/tests/data/test_validation.py
+++ b/tests/data/test_validation.py
@@ -17,11 +17,11 @@ class TestValidation(unittest.TestCase):
 
         json_string = '[{"file": "path", "id": "sha", "used_lines": [1, 2, 3, 5], "unused_lines": []}]'
         result_object = _validate_coverage_json(json_string)
-        self.assertTrue(result_object == expected_object)
+        self.assertEqual(result_object, expected_object)
 
         json_object = expected_object
         result_object = _validate_coverage_json(json_object)
-        self.assertTrue(result_object == expected_object)
+        self.assertEqual(result_object, expected_object)
 
     def test_coverage_json_invalid(self):
         """p3analysis.data.validation.coverage_json_invalid"""

--- a/tests/data/test_validation.py
+++ b/tests/data/test_validation.py
@@ -13,9 +13,14 @@ class TestValidation(unittest.TestCase):
 
     def test_coverage_json_valid(self):
         """p3analysis.data.validation.coverage_json_valid"""
+        expected_object = [{"file": "path", "id": "sha", "used_lines": [1, 2, 3, 5], "unused_lines": []}]
+
         json_string = '[{"file": "path", "id": "sha", "used_lines": [1, 2, 3, 5], "unused_lines": []}]'
         result_object = _validate_coverage_json(json_string)
-        expected_object = [{"file": "path", "id": "sha", "used_lines": [1, 2, 3, 5], "unused_lines": []}]
+        self.assertTrue(result_object == expected_object)
+
+        json_object = expected_object
+        result_object = _validate_coverage_json(json_object)
         self.assertTrue(result_object == expected_object)
 
     def test_coverage_json_invalid(self):


### PR DESCRIPTION
# Related issues

Closes #60. 

# Proposed changes

- Relax restrictions on types expected by coverage validation routine to permit JSON objects.
- Adjust `test_coverage_json_invalid` to reflect that passing objects is now valid.
- Adjust `test_coverage_json_valid` to test JSON objects as well as JSON strings.
