### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build-unittest.yml
+++ b/.github/workflows/build-unittest.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-precommit.yml
+++ b/.github/workflows/run-precommit.yml
@@ -8,7 +8,7 @@ jobs:
   pre-commit:
     strategy:
       matrix:
-        py_version: ["3.9", "3.10"]
+        py_version: ["3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-gallery.yml
+++ b/.github/workflows/test-gallery.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,17 +15,16 @@ description = "Performance, Portability and Productivity Analysis Library"
 dynamic = ["version", "readme"]
 keywords = ["performance", "portability", "productivity"]
 name = "p3analysis"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10"
+  "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-  "numpy",
-  "pandas",
-  "matplotlib>=3.6.3",
-  "jsonschema",
+  "numpy==2.2.4",
+  "pandas==2.2.3",
+  "matplotlib==3.10.1",
+  "jsonschema==4.23.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Related issues

- Should fix the test failures in #74.
- Aligned with the changes in https://github.com/intel/code-base-investigator/pull/193.

# Proposed changes

- Pin dependency versions to the same versions as those used by Code Base Investigator (or the latest, in the case of pandas).
- Require Python 3.12 as the minimum version of Python.
- Update GitHub Actions to test with Python 3.12 instead of older versions.
