### PR TITLE
replaces np.arange with range, fixing #59

### DIFF
--- a/p3analysis/plot/backend/pgfplots.py
+++ b/p3analysis/plot/backend/pgfplots.py
@@ -184,7 +184,7 @@ class CascadePlot(CascadePlot):
             app_df = app_df.sort_values(by=[eff_column], ascending=False)
             yvalues = app_df[eff_column]
             supported_platforms = list(app_df["platform"])
-            xvalues = np.arange(1, len(supported_platforms) + 1)
+            xvalues = range(1, len(supported_platforms) + 1)
             plot_effs[app_name] = tuple(zip(xvalues, yvalues))
 
         # Build a dictionary with "application name, (application name, qp)"


### PR DESCRIPTION
# Related issues

This PR fixed #59 replacing `np.arange` with `range`

# Proposed changes

Replacing np.arange with range on pgfplots.py:187 fixes the erroneous behaviour