### PR TITLE
Stop sphinx-gallery ignoring bbox_inches="tight"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ def tight_matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
     import sphinx_gallery
     from sphinx_gallery.scrapers import matplotlib_scraper
     kwargs["bbox_inches"] = "tight"
-    return sphinx_gallery.scrapers.matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
+    return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
 
 sphinx_gallery_conf = {
      'examples_dirs': ['../../examples','../../case-studies'],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,12 +37,20 @@ html_theme = "furo"
 html_static_path = ["_static"]
 html_title = "P3 Analysis Library"
 
+# Use a customized matplotlib scraper to ensure that tight layout is respected.
+def tight_matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
+    import sphinx_gallery
+    from sphinx_gallery.scrapers import matplotlib_scraper
+    kwargs["bbox_inches"] = "tight"
+    return sphinx_gallery.scrapers.matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
+
 sphinx_gallery_conf = {
      'examples_dirs': ['../../examples','../../case-studies'],
      'gallery_dirs': ['examples','case-studies'],
      'run_stale_examples': True,
      'filename_pattern': '/',
      'backreferences_dir'  : 'gen_modules/backreferences',
+     'image_scrapers': (tight_matplotlib_scraper,),
 }
 
 intersphinx_mapping = {


### PR DESCRIPTION
Both NavChart and CascadePlot set bbox_inches="tight", and this is respected when example scripts are run directly.

Surprisingly, sphinx-gallery does not scrape the .png files generated by these scripts, but instead intercepts calls to matplotlib. The default matplotlib scraper does not use bbox_inches="tight", resulting in the images being cropped in the online documentation.

Extending the default matplotlib scraper to pass bbox_inches as a kwarg solves the issue.

# Related issues

N/A

# Proposed changes

- Define a custom sphinx-gallery scraper by extending the default matplotlib scraper.
- Pass `bbox_inches="tight"` as an argument to the default matplotlib scraper to mimic the behavior of the library.
- Configure sphinx-gallery to use the custom scraper instead of the default matplotlib scraper.
